### PR TITLE
Simple fix for issues with AS Names

### DIFF
--- a/name.go
+++ b/name.go
@@ -11,7 +11,7 @@ type Name struct {
 
 //ParseName returns a pointer to a new name
 func ParseName(raw string) Name {
-	tokens := strings.Split(raw, "-")
+	tokens := strings.Split(raw, " - ")
 	if len(tokens) == 0 {
 		tokens = []string{raw}
 	}


### PR DESCRIPTION
This simple fix addresses issues where the AS name contains a `-`.  By adding spaces around the separator, the name is preserved instead of truncated.